### PR TITLE
feat: add transcription to analyze response

### DIFF
--- a/lib/api/soullog-api/doc/AnalyzeResponse.md
+++ b/lib/api/soullog-api/doc/AnalyzeResponse.md
@@ -9,6 +9,7 @@ import 'package:soullog_api/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **mood** | **String** |  | 
+**transcription** | **String** | Transcription of the diary entry. | 
 **recommendations** | [**BuiltList&lt;JsonObject&gt;**](JsonObject.md) |  | 
 **quote** | **String** |  | 
 **personality** | [**Persona**](Persona.md) |  | 

--- a/lib/api/soullog-api/lib/soullog_api.dart
+++ b/lib/api/soullog-api/lib/soullog_api.dart
@@ -3,19 +3,17 @@
 //
 
 export 'package:soullog_api/src/api.dart';
+export 'package:soullog_api/src/api/default_api.dart';
 export 'package:soullog_api/src/auth/api_key_auth.dart';
 export 'package:soullog_api/src/auth/basic_auth.dart';
 export 'package:soullog_api/src/auth/bearer_auth.dart';
 export 'package:soullog_api/src/auth/oauth.dart';
-export 'package:soullog_api/src/serializers.dart';
-export 'package:soullog_api/src/model/date.dart';
-
-export 'package:soullog_api/src/api/default_api.dart';
-
 export 'package:soullog_api/src/model/analyze_response.dart';
 export 'package:soullog_api/src/model/contextual_insight.dart';
+export 'package:soullog_api/src/model/date.dart';
 export 'package:soullog_api/src/model/http_validation_error.dart';
 export 'package:soullog_api/src/model/persona.dart';
 export 'package:soullog_api/src/model/short_term_state.dart';
 export 'package:soullog_api/src/model/validation_error.dart';
 export 'package:soullog_api/src/model/validation_error_loc_inner.dart';
+export 'package:soullog_api/src/serializersart';

--- a/lib/api/soullog-api/lib/src/api/default_api.dart
+++ b/lib/api/soullog-api/lib/src/api/default_api.dart
@@ -4,22 +4,12 @@
 
 import 'dart:async';
 
+import 'package:built_collection/built_collection.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:dio/dio.dart';
-
-import 'package:built_collection/built_collection.dart';
-import 'package:built_value/json_object.dart';
 import 'package:soullog_api/src/api_util.dart';
-import 'package:soullog_api/src/model/analyze_response.dart';
-import 'package:soullog_api/src/model/http_validation_error.dart';
-
-class DefaultApi {
-  final Dio _dio;
-
-  final Serializers _serializers;
-
-  const DefaultApi(this._dio, this._serializers);
+import 'package:soullog_api/src/model/analyze_responses._serializers);
 
   /// Analyze audio diary entry
   /// Transcribe audio, detect mood, and update user persona based on the transcript.

--- a/lib/api/soullog-api/lib/src/model/analyze_response.dart
+++ b/lib/api/soullog-api/lib/src/model/analyze_response.dart
@@ -2,12 +2,11 @@
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
 
-// ignore_for_file: unused_element
-import 'package:soullog_api/src/model/persona.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/json_object.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value/serializer.dart';
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart'; // ignore_for_file: unused_element
+import 'package:soullog_api/src/model/persona.dart';
 
 part 'analyze_response.g.dart';
 
@@ -15,15 +14,20 @@ part 'analyze_response.g.dart';
 ///
 /// Properties:
 /// * [mood]
+/// * [transcription] - Transcription of the diary entry.
 /// * [recommendations]
 /// * [quote]
 /// * [personality]
 @BuiltValue()
-abstract class AnalyzeResponse
-    implements Built<AnalyzeResponse, AnalyzeResponseBuilder> {
+abstract class AnalyzeResponse implements Built<AnalyzeResponse, AnalyzeResponseBuilder> {
   @BuiltValueField(wireName: r'mood')
   AnalyzeResponseMoodEnum get mood;
+
   // enum moodEnum {  happy,  sad,  calm,  fearful,  angry,  disgust,  neutral,  suprised,  };
+
+  /// Transcription of the diary entry.
+  @BuiltValueField(wireName: r'transcription')
+  String get transcription;
 
   @BuiltValueField(wireName: r'recommendations')
   BuiltList<JsonObject?> get recommendations;
@@ -36,19 +40,16 @@ abstract class AnalyzeResponse
 
   AnalyzeResponse._();
 
-  factory AnalyzeResponse([void updates(AnalyzeResponseBuilder b)]) =
-      _$AnalyzeResponse;
+  factory AnalyzeResponse([void updates(AnalyzeResponseBuilder b)]) = _$AnalyzeResponse;
 
   @BuiltValueHook(initializeBuilder: true)
   static void _defaults(AnalyzeResponseBuilder b) => b;
 
   @BuiltValueSerializer(custom: true)
-  static Serializer<AnalyzeResponse> get serializer =>
-      _$AnalyzeResponseSerializer();
+  static Serializer<AnalyzeResponse> get serializer => _$AnalyzeResponseSerializer();
 }
 
-class _$AnalyzeResponseSerializer
-    implements PrimitiveSerializer<AnalyzeResponse> {
+class _$AnalyzeResponseSerializer implements PrimitiveSerializer<AnalyzeResponse> {
   @override
   final Iterable<Type> types = const [AnalyzeResponse, _$AnalyzeResponse];
 
@@ -64,6 +65,11 @@ class _$AnalyzeResponseSerializer
     yield serializers.serialize(
       object.mood,
       specifiedType: const FullType(AnalyzeResponseMoodEnum),
+    );
+    yield r'transcription';
+    yield serializers.serialize(
+      object.transcription,
+      specifiedType: const FullType(String),
     );
     yield r'recommendations';
     yield serializers.serialize(
@@ -88,9 +94,7 @@ class _$AnalyzeResponseSerializer
     AnalyzeResponse object, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    return _serializeProperties(serializers, object,
-            specifiedType: specifiedType)
-        .toList();
+    return _serializeProperties(serializers, object, specifiedType: specifiedType).toList();
   }
 
   void _deserializeProperties(
@@ -112,11 +116,17 @@ class _$AnalyzeResponseSerializer
           ) as AnalyzeResponseMoodEnum;
           result.mood = valueDes;
           break;
+        case r'transcription':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.transcription = valueDes;
+          break;
         case r'recommendations':
           final valueDes = serializers.deserialize(
             value,
-            specifiedType:
-                const FullType(BuiltList, [FullType.nullable(JsonObject)]),
+            specifiedType: const FullType(BuiltList, [FullType.nullable(JsonObject)]),
           ) as BuiltList<JsonObject?>;
           result.recommendations.replace(valueDes);
           break;
@@ -171,27 +181,21 @@ class AnalyzeResponseMoodEnum extends EnumClass {
   @BuiltValueEnumConst(wireName: r'calm')
   static const AnalyzeResponseMoodEnum calm = _$analyzeResponseMoodEnum_calm;
   @BuiltValueEnumConst(wireName: r'fearful')
-  static const AnalyzeResponseMoodEnum fearful =
-      _$analyzeResponseMoodEnum_fearful;
+  static const AnalyzeResponseMoodEnum fearful = _$analyzeResponseMoodEnum_fearful;
   @BuiltValueEnumConst(wireName: r'angry')
   static const AnalyzeResponseMoodEnum angry = _$analyzeResponseMoodEnum_angry;
   @BuiltValueEnumConst(wireName: r'disgust')
-  static const AnalyzeResponseMoodEnum disgust =
-      _$analyzeResponseMoodEnum_disgust;
+  static const AnalyzeResponseMoodEnum disgust = _$analyzeResponseMoodEnum_disgust;
   @BuiltValueEnumConst(wireName: r'neutral')
-  static const AnalyzeResponseMoodEnum neutral =
-      _$analyzeResponseMoodEnum_neutral;
+  static const AnalyzeResponseMoodEnum neutral = _$analyzeResponseMoodEnum_neutral;
   @BuiltValueEnumConst(wireName: r'suprised')
-  static const AnalyzeResponseMoodEnum suprised =
-      _$analyzeResponseMoodEnum_suprised;
+  static const AnalyzeResponseMoodEnum suprised = _$analyzeResponseMoodEnum_suprised;
 
-  static Serializer<AnalyzeResponseMoodEnum> get serializer =>
-      _$analyzeResponseMoodEnumSerializer;
+  static Serializer<AnalyzeResponseMoodEnum> get serializer => _$analyzeResponseMoodEnumSerializer;
 
   const AnalyzeResponseMoodEnum._(String name) : super(name);
 
-  static BuiltSet<AnalyzeResponseMoodEnum> get values =>
-      _$analyzeResponseMoodEnumValues;
-  static AnalyzeResponseMoodEnum valueOf(String name) =>
-      _$analyzeResponseMoodEnumValueOf(name);
+  static BuiltSet<AnalyzeResponseMoodEnum> get values => _$analyzeResponseMoodEnumValues;
+
+  static AnalyzeResponseMoodEnum valueOf(String name) => _$analyzeResponseMoodEnumValueOf(name);
 }

--- a/lib/api/soullog-api/lib/src/model/analyze_response.g.dart
+++ b/lib/api/soullog-api/lib/src/model/analyze_response.g.dart
@@ -110,6 +110,8 @@ class _$AnalyzeResponse extends AnalyzeResponse {
   @override
   final AnalyzeResponseMoodEnum mood;
   @override
+  final String transcription;
+  @override
   final BuiltList<JsonObject?> recommendations;
   @override
   final String quote;
@@ -121,6 +123,7 @@ class _$AnalyzeResponse extends AnalyzeResponse {
 
   _$AnalyzeResponse._({
     required this.mood,
+    required this.transcription,
     required this.recommendations,
     required this.quote,
     required this.personality,
@@ -137,6 +140,7 @@ class _$AnalyzeResponse extends AnalyzeResponse {
     if (identical(other, this)) return true;
     return other is AnalyzeResponse &&
         mood == other.mood &&
+        transcription == other.transcription &&
         recommendations == other.recommendations &&
         quote == other.quote &&
         personality == other.personality;
@@ -146,6 +150,7 @@ class _$AnalyzeResponse extends AnalyzeResponse {
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, mood.hashCode);
+    _$hash = $jc(_$hash, transcription.hashCode);
     _$hash = $jc(_$hash, recommendations.hashCode);
     _$hash = $jc(_$hash, quote.hashCode);
     _$hash = $jc(_$hash, personality.hashCode);
@@ -157,6 +162,7 @@ class _$AnalyzeResponse extends AnalyzeResponse {
   String toString() {
     return (newBuiltValueToStringHelper(r'AnalyzeResponse')
           ..add('mood', mood)
+          ..add('transcription', transcription)
           ..add('recommendations', recommendations)
           ..add('quote', quote)
           ..add('personality', personality))
@@ -171,6 +177,11 @@ class AnalyzeResponseBuilder
   AnalyzeResponseMoodEnum? _mood;
   AnalyzeResponseMoodEnum? get mood => _$this._mood;
   set mood(AnalyzeResponseMoodEnum? mood) => _$this._mood = mood;
+
+  String? _transcription;
+  String? get transcription => _$this._transcription;
+  set transcription(String? transcription) =>
+      _$this._transcription = transcription;
 
   ListBuilder<JsonObject?>? _recommendations;
   ListBuilder<JsonObject?> get recommendations =>
@@ -195,6 +206,7 @@ class AnalyzeResponseBuilder
     final $v = _$v;
     if ($v != null) {
       _mood = $v.mood;
+      _transcription = $v.transcription;
       _recommendations = $v.recommendations.toBuilder();
       _quote = $v.quote;
       _personality = $v.personality.toBuilder();
@@ -226,6 +238,11 @@ class AnalyzeResponseBuilder
               mood,
               r'AnalyzeResponse',
               'mood',
+            ),
+            transcription: BuiltValueNullFieldError.checkNotNull(
+              transcription,
+              r'AnalyzeResponse',
+              'transcription',
             ),
             recommendations: recommendations.build(),
             quote: BuiltValueNullFieldError.checkNotNull(

--- a/lib/api/soullog-api/lib/src/model/persona.dart
+++ b/lib/api/soullog-api/lib/src/model/persona.dart
@@ -2,12 +2,12 @@
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
 
-// ignore_for_file: unused_element
-import 'package:soullog_api/src/model/contextual_insight.dart';
-import 'package:soullog_api/src/model/short_term_state.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
+// ignore_for_file: unused_element
+import 'package:soullog_api/src/model/contextual_insight.dart';
+import 'package:soullog_api/src/model/short_term_state.dart';
 
 part 'persona.g.dart';
 
@@ -77,9 +77,7 @@ class _$PersonaSerializer implements PrimitiveSerializer<Persona> {
     Persona object, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    return _serializeProperties(serializers, object,
-            specifiedType: specifiedType)
-        .toList();
+    return _serializeProperties(serializers, object, specifiedType: specifiedType).toList();
   }
 
   void _deserializeProperties(
@@ -104,16 +102,14 @@ class _$PersonaSerializer implements PrimitiveSerializer<Persona> {
         case r'short_term_states':
           final valueDes = serializers.deserialize(
             value,
-            specifiedType:
-                const FullType(BuiltList, [FullType(ShortTermState)]),
+            specifiedType: const FullType(BuiltList, [FullType(ShortTermState)]),
           ) as BuiltList<ShortTermState>;
           result.shortTermStates.replace(valueDes);
           break;
         case r'contextual_insights':
           final valueDes = serializers.deserialize(
             value,
-            specifiedType:
-                const FullType(BuiltList, [FullType(ContextualInsight)]),
+            specifiedType: const FullType(BuiltList, [FullType(ContextualInsight)]),
           ) as BuiltList<ContextualInsight>;
           result.contextualInsights.replace(valueDes);
           break;

--- a/lib/api/soullog-api/lib/src/serializers.dart
+++ b/lib/api/soullog-api/lib/src/serializers.dart
@@ -4,18 +4,17 @@
 
 // ignore_for_file: unused_import
 
-import 'package:one_of_serializer/any_of_serializer.dart';
-import 'package:one_of_serializer/one_of_serializer.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:built_value/iso_8601_date_time_serializer.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
-import 'package:built_value/iso_8601_date_time_serializer.dart';
+import 'package:one_of_serializer/any_of_serializer.dart';
+import 'package:one_of_serializer/one_of_serializer.dart';
 import 'package:soullog_api/src/date_serializer.dart';
-import 'package:soullog_api/src/model/date.dart';
-
 import 'package:soullog_api/src/model/analyze_response.dart';
 import 'package:soullog_api/src/model/contextual_insight.dart';
+import 'package:soullog_api/src/model/datedart';
 import 'package:soullog_api/src/model/http_validation_error.dart';
 import 'package:soullog_api/src/model/persona.dart';
 import 'package:soullog_api/src/model/short_term_state.dart';
@@ -44,5 +43,4 @@ Serializers serializers = (_$serializers.toBuilder()
       ..add(Iso8601DateTimeSerializer()))
     .build();
 
-Serializers standardSerializers =
-    (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+Serializers standardSerializers = (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();


### PR DESCRIPTION
This commit adds a `transcription` field to the `AnalyzeResponse` model. The field is of type `String` and represents the transcription of the diary entry.