### PR TITLE
feat: Add NoDataView and improve chart data handling

### DIFF
--- a/lib/components/filterList.dart
+++ b/lib/components/filterList.dart
@@ -1,3 +1,4 @@
+import 'package:Soullog/components/noDataView.dart';
 import 'package:Soullog/views/recordList/FastCheckInCard.dart';
 import 'package:Soullog/views/recordList/RecordCard.dart';
 import 'package:flutter/material.dart';
@@ -139,42 +140,51 @@ class _FilterListState extends State<FilterList> {
             ),
           ),
           Expanded(
-            child: ListView.builder(
-              itemCount: filterRecordings.length,
-              itemBuilder: (context, index) {
-                final recording = filterRecordings[index];
-                Widget cardWidget =
-                    recording.isFastCheckIn ? FastCheckInCard(recording: recording) : RecordCard(recording: recording);
+            child:
+                filterRecordings.isEmpty
+                    ? const NoDataView(
+                      title: 'No entries found',
+                      subtitle: 'Try other filters or create a new entry',
+                      icon: Icons.search_off,
+                    )
+                    : ListView.builder(
+                      itemCount: filterRecordings.length,
+                      itemBuilder: (context, index) {
+                        final recording = filterRecordings[index];
+                        Widget cardWidget =
+                            recording.isFastCheckIn
+                                ? FastCheckInCard(recording: recording)
+                                : RecordCard(recording: recording);
 
-                return GestureDetector(
-                  onLongPress: () {
-                    setState(() {
-                      if (!_selectedRecordings.contains(recording)) {
-                        _selectedRecordings.add(recording);
-                      }
-                      _toggleSelectionMode();
-                    });
-                  },
-                  child:
-                      _isSelectionMode
-                          ? CheckboxListTile(
-                            controlAffinity: ListTileControlAffinity.leading,
-                            value: _selectedRecordings.contains(recording),
-                            onChanged: (bool? selected) {
-                              setState(() {
-                                if (selected == true) {
-                                  _selectedRecordings.add(recording);
-                                } else {
-                                  _selectedRecordings.remove(recording);
-                                }
-                              });
-                            },
-                            title: cardWidget,
-                          )
-                          : cardWidget,
-                );
-              },
-            ),
+                        return GestureDetector(
+                          onLongPress: () {
+                            setState(() {
+                              if (!_selectedRecordings.contains(recording)) {
+                                _selectedRecordings.add(recording);
+                              }
+                              _toggleSelectionMode();
+                            });
+                          },
+                          child:
+                              _isSelectionMode
+                                  ? CheckboxListTile(
+                                    controlAffinity: ListTileControlAffinity.leading,
+                                    value: _selectedRecordings.contains(recording),
+                                    onChanged: (bool? selected) {
+                                      setState(() {
+                                        if (selected == true) {
+                                          _selectedRecordings.add(recording);
+                                        } else {
+                                          _selectedRecordings.remove(recording);
+                                        }
+                                      });
+                                    },
+                                    title: cardWidget,
+                                  )
+                                  : cardWidget,
+                        );
+                      },
+                    ),
           ),
         ],
       ),

--- a/lib/components/noDataView.dart
+++ b/lib/components/noDataView.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class NoDataView extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final Color color;
+  final double iconSize;
+
+  const NoDataView({
+    super.key,
+    this.title = 'No mood data available',
+    this.subtitle = 'Start with your first entry!',
+    this.icon = Icons.sentiment_dissatisfied,
+    this.color = Colors.grey,
+    this.iconSize = 50,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: iconSize, color: color),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: color),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(subtitle, style: TextStyle(fontSize: 14, color: color), textAlign: TextAlign.center),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/data/db.dart
+++ b/lib/data/db.dart
@@ -13,7 +13,7 @@ import 'package:sqflite/sqflite.dart';
 import '../../data/models/plotCard.dart';
 
 class RecordsDB {
-  static final RecordsDB _instance = RecordsDB._internal();
+  static RecordsDB? _instance;
   static bool _initialized = false;
   final _todaysPlotCard = BehaviorSubject<PlotCard?>();
 
@@ -28,11 +28,12 @@ class RecordsDB {
   RecordsDB._internal();
 
   static Future<RecordsDB> getInstance() async {
-    if (!_initialized) {
-      await _instance._init();
+    if (_instance == null) {
+      _instance = RecordsDB._internal();
+      await _instance!._init();
       _initialized = true;
     }
-    return _instance;
+    return _instance!;
   }
 
   final String _databaseName = 'records.db';
@@ -109,11 +110,9 @@ class RecordsDB {
       });
     }
 
-    _initialized = true;
     if (kDebugMode) {
       print('Database initialization process completed in _init.');
     }
-
     // Load today's PlotCard if it exists
     await loadTodaysPlotCard();
   }

--- a/lib/helper/chartHelpers.dart
+++ b/lib/helper/chartHelpers.dart
@@ -22,6 +22,7 @@ List<PieChartSection> calculateSections(List<Recording> records) {
       ),
     );
   }
+  sections.removeWhere((section) => section.value == 0);
   return sections;
 }
 

--- a/lib/views/dashboard/moodLinechart.dart
+++ b/lib/views/dashboard/moodLinechart.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:Soullog/components/loadingIndicator.dart';
+import 'package:Soullog/components/noDataView.dart';
 import 'package:Soullog/data/constants/emotions.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/foundation.dart';
@@ -65,7 +66,12 @@ class _MoodLineChartState extends State<MoodLineChart> {
           aspectRatio: 1.1,
           child: Padding(
             padding: const EdgeInsets.only(right: 18, left: 12, top: 24, bottom: 12),
-            child: widget.isLoading ? loadingIndicator() : LineChart(mainData(_plotPoints, _gradientColors)),
+            child:
+                widget.isLoading
+                    ? loadingIndicator()
+                    : widget.spots.isEmpty
+                    ? const NoDataView()
+                    : LineChart(mainData(_plotPoints, _gradientColors)),
           ),
         ),
       ],

--- a/lib/views/dashboard/moodPiechart.dart
+++ b/lib/views/dashboard/moodPiechart.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:Soullog/components/loadingIndicator.dart';
+import 'package:Soullog/components/noDataView.dart';
 import 'package:Soullog/data/constants/emotions.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/foundation.dart';
@@ -49,6 +50,12 @@ class MoodPieChartState extends State<MoodPieChart> {
               child:
                   widget.isLoading
                       ? loadingIndicator()
+                      : widget.sectionsData.isEmpty
+                      ? const NoDataView(
+                        title: 'No mood data available',
+                        subtitle: 'There is no data for the distribution',
+                        icon: Icons.pie_chart_outline,
+                      )
                       : PieChart(
                         PieChartData(
                           pieTouchData: PieTouchData(

--- a/lib/views/home/home.dart
+++ b/lib/views/home/home.dart
@@ -51,10 +51,7 @@ class _HomeState extends State<Home> {
               width: double.infinity,
               margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
               padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: const Color(0xFFFFFFFF),
-                borderRadius: BorderRadius.circular(10),
-              ),
+              decoration: BoxDecoration(color: const Color(0xFFFFFFFF), borderRadius: BorderRadius.circular(10)),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
@@ -89,37 +86,22 @@ class _HomeState extends State<Home> {
             GestureDetector(
               behavior: HitTestBehavior.translucent,
               onTap: () {
-                Navigator.of(
-                  context,
-                ).push(MaterialPageRoute(builder: (context) => Dashboard()));
+                Navigator.of(context).push(MaterialPageRoute(builder: (context) => Dashboard()));
               },
               child: AbsorbPointer(
                 child: Container(
                   width: double.infinity,
                   margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
                   padding: const EdgeInsets.all(16),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFFFFFFF),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
+                  decoration: BoxDecoration(color: const Color(0xFFFFFFFF), borderRadius: BorderRadius.circular(10)),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
-                      const Text(
-                        'Mood of the past 7 days:',
-                        style: h1Black,
-                        textAlign: TextAlign.center,
-                      ),
+                      const Text('Mood of the past 7 days:', style: h1Black, textAlign: TextAlign.center),
                       ValueListenableBuilder<List<FlSpot>>(
                         valueListenable: moodSpotsNotifier.spots,
                         builder: (context, spots, _) {
-                          if (spots.isEmpty) {
-                            return const CircularProgressIndicator();
-                          }
-                          return SizedBox(
-                            width: double.infinity,
-                            child: MoodLineChart(spots: spots),
-                          );
+                          return SizedBox(width: double.infinity, child: MoodLineChart(spots: spots));
                         },
                       ),
                     ],
@@ -136,11 +118,7 @@ class _HomeState extends State<Home> {
                 children: [
                   Expanded(
                     flex: 1, // 50% der Breite
-                    child: Text(
-                      'Review past thoughts?',
-                      style: h1White,
-                      softWrap: true,
-                    ), // Text kann umbrechen
+                    child: Text('Review past thoughts?', style: h1White, softWrap: true), // Text kann umbrechen
                   ),
                   SizedBox(width: 15), // Abstand zwischen Text und Button
                   Expanded(
@@ -148,9 +126,7 @@ class _HomeState extends State<Home> {
                     child: ElevatedButton(
                       style: greyButtonStyle,
                       onPressed: () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(builder: (context) => RecordList()),
-                        );
+                        Navigator.of(context).push(MaterialPageRoute(builder: (context) => RecordList()));
                       },
                       child: const Text('To your entries'),
                     ),


### PR DESCRIPTION
This commit introduces a `NoDataView` component to display when there's no data available for charts or lists.

Specific changes include:
- Added `NoDataView` component for displaying a message when no data is available.
- Updated `MoodLineChart` and `MoodPieChart` to show `NoDataView` when `spots` or `sectionsData` are empty, respectively.
- Updated `FilterList` to show `NoDataView` when `filterRecordings` is empty.
- Modified `calculatePieChartSections` in `chartHelpers.dart` to remove sections with a value of 0.
- Refactored `RecordsDB` to use a nullable `_instance` and ensure initialization only happens once.